### PR TITLE
Improve stability & observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,85 @@ allowunmodified = true
 ```
 
 Referring to the "allowlist" file is done on the commandline by using the `-override` flag as follows: `hadrianus -override=allowlist.conf -minimumtimeinterval=14 2003 2103 2203 server01.iambk.com:2303`
+
+## Internal metrics
+
+Hadrianus (currently) exposes metrics on the path `server.hadrianus.<servername>.*`.
+
+Please note that the values of the metrics correspond to the `statstimegranularity` specified. For example: if `receivedMessage` has a value of 4.23 million, and the granularity of stats is 60 seconds, this will mean that the number of received messages per second is `4,230,000 / 60`, which equals `70,500` messages per second.
+
+### discardedChattyMessage
+
+The number of messages that have been discarded because they are coming in faster than is allowed by the `minimumtimeinterval` setting.
+
+### discardedStaleMessage
+
+The number of messages that have been discarded because they have been judged to be "stale" due to their values not changing often enough, or ever, as decided by the `maxdrymessages` setting.
+
+### discardedStaleAndChattyMessage
+
+The number of messages that have been discarded *both* because they have been judged to be stale and because they are coming in too fast.
+
+### encounteredMetricPaths
+
+The number of unique metric paths that have been encountered so far, during the running time of the service.
+
+### staleMetricPaths
+
+The number of unique metric paths that are judged to be "stale", as decided by the `maxdrymessages` setting. These messages will not be sent to the downstream metrics consumers.
+
+### garbageCollectionPauseMs
+
+The amount of time that has been spent on doing garbage collection.
+
+### garbageCollections
+
+The number of garbage collection operations that have been performed.
+
+### receivedMessage
+
+The number of messages that have been received from metrics producers.
+
+### sentMessage
+
+The number of messages that have been sent to the downstream metrics consumers after filtering and throttling operations have been applied.
+
+### invalidMessage
+
+The number of messages that have been received which do not correspond to valid Graphite wire protocol messages.
+
+### allocatedMemoryMegabytes
+
+The amount of memory allocated by the service in Megabytes.
+
+### clientConnectionOpening
+
+The number of opened TCP connections.
+
+### clientConnectionClosing
+
+The number of closed TCP connections.
+
+### clientConnectionsActive
+
+The number of currently active TCP connections.
+
+### goroutines
+
+The number of goroutines currently used. This will typically only change when the number of concurrent network connections changes.
+
+### toOutPoolOverflows
+
+The number of overflows when the output connection pool channel buffer is written to. If this goes up, it can indicate a severe performance issue.
+
+### incomingMessageOverflows
+
+The number of overflows when the incoming metrics producer channel buffer is being written to.
+
+### toOutConnectionOverflows
+
+The number of overflows when the output connection channel buffers are written to. If this goes up, it's possible that downstream metrics consumers cannot consume data fast enough.
+
+### cleanupTimeMilli
+
+The time in milliseconds that it took for the "cleanup" job to complete. This job will halt the central processing of data. If this takes a long time, it can stop the whole service and cause things to queue up.

--- a/channels.go
+++ b/channels.go
@@ -1,14 +1,12 @@
 package main
 
-/*
-Break out channel writes into separate functions to simplify handling of channel buffers.
-*/
+// Break out channel writes into separate functions.
+// This is done toto simplify handling of channel buffers.
 
 func writeStats(statsCounterChannel chan statUpdate, update statUpdate) {
 	select {
 	case statsCounterChannel <- update:
 	default:
-		writeStats(statsCounterChannel, statUpdate{IncrementCounter, pathStatsOverflows, 0})
 		if BlockOnChannelBufferFull {
 			statsCounterChannel <- update
 		}
@@ -20,12 +18,9 @@ func writeToOutPool(outgoingToPoolChannel chan metricMessage, update metricMessa
 	case outgoingToPoolChannel <- update:
 	default:
 		writeStats(statsCounterChannel, statUpdate{IncrementCounter, pathToOutPoolOverflows, 0})
-		/*
-			// It *seems* like the process is likely to hang if this is blocking. Let's disable that for now.
-			if BlockOnChannelBufferFull {
-				outgoingToPoolChannel <- update
-			}
-		*/
+		if BlockOnChannelBufferFull {
+			outgoingToPoolChannel <- update
+		}
 	}
 }
 
@@ -34,13 +29,9 @@ func writeIncomingMessage(incomingMessageChannel chan metricMessage, update metr
 	case incomingMessageChannel <- update:
 	default:
 		writeStats(statsCounterChannel, statUpdate{IncrementCounter, pathIncomingMessageOverflows, 0})
-		/*
-			// It *seems* like there's a big increase in sockets in CLOSE_WAIT state when it crashes.
-			// If we stop blocking on incoming messages, does this stop happening?
-			if BlockOnChannelBufferFull {
-				incomingMessageChannel <- update
-			}
-		*/
+		if BlockOnChannelBufferFull {
+			incomingMessageChannel <- update
+		}
 	}
 }
 

--- a/channels.go
+++ b/channels.go
@@ -1,0 +1,56 @@
+package main
+
+/*
+Break out channel writes into separate functions to simplify handling of channel buffers.
+*/
+
+func writeStats(statsCounterChannel chan statUpdate, update statUpdate) {
+	select {
+	case statsCounterChannel <- update:
+	default:
+		writeStats(statsCounterChannel, statUpdate{IncrementCounter, pathStatsOverflows, 0})
+		if BlockOnChannelBufferFull {
+			statsCounterChannel <- update
+		}
+	}
+}
+
+func writeToOutPool(outgoingToPoolChannel chan metricMessage, update metricMessage, statsCounterChannel chan statUpdate) {
+	select {
+	case outgoingToPoolChannel <- update:
+	default:
+		writeStats(statsCounterChannel, statUpdate{IncrementCounter, pathToOutPoolOverflows, 0})
+		/*
+			// It *seems* like the process is likely to hang if this is blocking. Let's disable that for now.
+			if BlockOnChannelBufferFull {
+				outgoingToPoolChannel <- update
+			}
+		*/
+	}
+}
+
+func writeIncomingMessage(incomingMessageChannel chan metricMessage, update metricMessage, statsCounterChannel chan statUpdate) {
+	select {
+	case incomingMessageChannel <- update:
+	default:
+		writeStats(statsCounterChannel, statUpdate{IncrementCounter, pathIncomingMessageOverflows, 0})
+		/*
+			// It *seems* like there's a big increase in sockets in CLOSE_WAIT state when it crashes.
+			// If we stop blocking on incoming messages, does this stop happening?
+			if BlockOnChannelBufferFull {
+				incomingMessageChannel <- update
+			}
+		*/
+	}
+}
+
+func writeToOutConnection(outgoingToPoolChannel chan metricMessage, update metricMessage, statsCounterChannel chan statUpdate) {
+	select {
+	case outgoingToPoolChannel <- update:
+	default:
+		writeStats(statsCounterChannel, statUpdate{IncrementCounter, pathToOutConnectionOverflows, 0})
+		if BlockOnChannelBufferFull {
+			outgoingToPoolChannel <- update
+		}
+	}
+}

--- a/connections.go
+++ b/connections.go
@@ -61,7 +61,11 @@ func createOutgoingConnection(outgoingHostPort string, outgoingMessageChannel ch
 	for {
 		addr, _ := net.ResolveTCPAddr("tcp", outgoingHostPort)
 		connection, err := net.DialTCP("tcp", nil, addr)
-		connection.SetNoDelay(TcpNoDelay)
+		err2 := connection.SetNoDelay(TcpNoDelay)
+		if err2 != nil {
+			log.Println("Attempt to set \"NoDelay\" failed:", err.Error())
+			os.Exit(1)
+		}
 
 		if err != nil {
 			log.Println("Failed to connect to", outgoingHostPort+":", err.Error())
@@ -91,8 +95,7 @@ func handleOutgoingPool(outgoingToPoolChannel chan metricMessage, outgoingHostPo
 		var emptySlice []chan metricMessage
 		outgoingMessageChannel = append(outgoingMessageChannel, emptySlice)
 		for connectionInPool := 0; connectionInPool < numberOutConnections[currentPool]; connectionInPool++ {
-			outgoingMessageChannel[currentPool] = append(outgoingMessageChannel[currentPool], make(chan metricMessage, OutgoingMessageBuffer))
-			outgoingMessageChannel[currentPool][connectionInPool] = make(chan metricMessage, PoolChannelBufferSize)
+			outgoingMessageChannel[currentPool] = append(outgoingMessageChannel[currentPool], make(chan metricMessage, OutgoingChannelSize))
 			go createOutgoingConnection(outgoingHostPort[currentPool][connectionInPool], outgoingMessageChannel[currentPool][connectionInPool])
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -15,11 +15,10 @@ import (
 )
 
 const (
-	OutgoingMessageBuffer    = 16777216
-	IncomingMessageBuffer    = 65536
-	PoolChannelSize          = 16777216 // Was historically set to 1024
-	StatsChannelSize         = 65536
-	PoolChannelBufferSize    = 1024
+	OutgoingChannelSize      = 65536
+	IncomingChannelSize      = 65536
+	PoolChannelSize          = 65536
+	StatsChannelSize         = 32768
 	NanosecondsInMillisecond = 1000000
 	BytesInMegabyte          = 1048576
 
@@ -66,7 +65,6 @@ var (
 	pathClientConnectionClosing        string
 	pathClientConnectionsActive        string
 	pathGoroutines                     string
-	pathStatsOverflows                 string
 	pathToOutPoolOverflows             string
 	pathIncomingMessageOverflows       string
 	pathToOutConnectionOverflows       string
@@ -169,7 +167,7 @@ func main() {
 	initializeInternalMetricsPaths()
 
 	statsCounterChannel := make(chan statUpdate, StatsChannelSize)
-	incomingMessageChannel := make(chan metricMessage, IncomingMessageBuffer)
+	incomingMessageChannel := make(chan metricMessage, IncomingChannelSize)
 	outgoingToPoolChannel := make(chan metricMessage, PoolChannelSize)
 
 	// Create listener for stats channel

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"runtime"
 	"runtime/debug"
 	"strconv"
@@ -14,9 +15,11 @@ import (
 )
 
 const (
-	OutgoingMessageBuffer    = 65536
-	IncomingMessageBuffer    = 524288
-	PoolChannelSize          = 65536 // Was historically set to 1024
+	OutgoingMessageBuffer    = 16777216
+	IncomingMessageBuffer    = 65536
+	PoolChannelSize          = 16777216 // Was historically set to 1024
+	StatsChannelSize         = 65536
+	PoolChannelBufferSize    = 1024
 	NanosecondsInMillisecond = 1000000
 	BytesInMegabyte          = 1048576
 
@@ -27,6 +30,9 @@ const (
 	MaxConsecutiveDryMessages   = 120 // If more than this number of messages with the same value have been sent, mark as "stale"
 	IsNewMetricEnabledByDefault = false
 	StaleResendInterval         = 0
+
+	BlockOnChannelBufferFull = true
+	TcpNoDelay               = false // Disable delay of sending successive small packets
 )
 
 // Commandline flag variable definitions
@@ -59,6 +65,12 @@ var (
 	pathClientConnectionOpening        string
 	pathClientConnectionClosing        string
 	pathClientConnectionsActive        string
+	pathGoroutines                     string
+	pathStatsOverflows                 string
+	pathToOutPoolOverflows             string
+	pathIncomingMessageOverflows       string
+	pathToOutConnectionOverflows       string
+	pathCleanupTimeMilli               string
 )
 
 var timeToCleanup = false
@@ -67,6 +79,7 @@ type StatUpdateType int
 
 const (
 	IncrementCounter StatUpdateType = iota
+	IncreaseCounter
 	SetCounterValue
 	IncrementGauge
 	DecrementGauge
@@ -141,13 +154,21 @@ func main() {
 
 	// Process and sanity check override file argument
 	var storageSchema map[string]overrideData
+
 	if len(*override) > 0 {
 		storageSchema = getStorageSchemaFromFile(*override)
 	}
 
+	// Automatically whitelist internal hadrianus metrics
+	if len(storageSchema) == 0 {
+		storageSchema = make(map[string]overrideData)
+	}
+	internalHadrianusPattern, _ := regexp.Compile(`^server\.hadrianus\.`)
+	storageSchema[`hadrianus`] = overrideData{pattern: internalHadrianusPattern, allowUnmodifiedActive: true, allowUnmodified: true}
+
 	initializeInternalMetricsPaths()
 
-	statsCounterChannel := make(chan statUpdate, 1024)
+	statsCounterChannel := make(chan statUpdate, StatsChannelSize)
 	incomingMessageChannel := make(chan metricMessage, IncomingMessageBuffer)
 	outgoingToPoolChannel := make(chan metricMessage, PoolChannelSize)
 
@@ -158,7 +179,7 @@ func main() {
 	go createIncomingConnections(incomingPort, incomingMessageChannel, statsCounterChannel)
 
 	// Create outgoing pool
-	go handleOutgoingPool(outgoingToPoolChannel, outgoingHostPort)
+	go handleOutgoingPool(outgoingToPoolChannel, outgoingHostPort, statsCounterChannel)
 
 	metric := make(map[string]*metricData)
 
@@ -170,15 +191,18 @@ func main() {
 		for range time.Tick(d) {
 			// Update GC stats
 			debug.ReadGCStats(&garbageCollectionStats)
-			statsCounterChannel <- statUpdate{SetCounterValue, pathGarbageCollections, int64(garbageCollectionStats.NumGC)}
-			statsCounterChannel <- statUpdate{SetCounterValue, pathGarbageCollectionPauseMs, int64(garbageCollectionStats.PauseTotal / NanosecondsInMillisecond)}
+			writeStats(statsCounterChannel, statUpdate{SetCounterValue, pathGarbageCollections, int64(garbageCollectionStats.NumGC)})
+			writeStats(statsCounterChannel, statUpdate{SetCounterValue, pathGarbageCollectionPauseMs, int64(garbageCollectionStats.PauseTotal / NanosecondsInMillisecond)})
 
 			// Update memory stats
 			runtime.ReadMemStats(&memoryStats)
-			statsCounterChannel <- statUpdate{SetGaugeValue, pathAllocatedMemoryMegabytes, int64(memoryStats.Alloc / BytesInMegabyte)}
+			writeStats(statsCounterChannel, statUpdate{SetGaugeValue, pathAllocatedMemoryMegabytes, int64(memoryStats.Alloc / BytesInMegabyte)})
+
+			// Update goroutine stats
+			writeStats(statsCounterChannel, statUpdate{SetGaugeValue, pathGoroutines, int64(runtime.NumGoroutine())})
 
 			// Trigger generation of stats for counters
-			statsCounterChannel <- statUpdate{updateType: Generate}
+			writeStats(statsCounterChannel, statUpdate{updateType: Generate})
 		}
 	}()
 
@@ -199,7 +223,7 @@ func main() {
 
 		// Check if data for the metric path needs to be created
 		if instance, found = metric[fromConnection.metricPath]; !found {
-			statsCounterChannel <- statUpdate{IncrementGauge, pathEncounteredMetricPaths, 0}
+			writeStats(statsCounterChannel, statUpdate{IncrementGauge, pathEncounteredMetricPaths, 0})
 
 			// Initialize data for newly discovered metric
 			instance = &metricData{
@@ -211,7 +235,7 @@ func main() {
 				allowUnmodified:  false,
 			}
 			if !*isNewMetricEnabledByDefault {
-				statsCounterChannel <- statUpdate{IncrementGauge, pathStaleMetricPaths, 0}
+				writeStats(statsCounterChannel, statUpdate{IncrementGauge, pathStaleMetricPaths, 0})
 			}
 
 			// Check if the newly discovered metric path matches patterns in the override file
@@ -234,9 +258,9 @@ func main() {
 
 		// If metric path is allowUnmodified, send it out, no matter what.
 		if instance.allowUnmodified {
-			outgoingToPoolChannel <- fromConnection
+			writeToOutPool(outgoingToPoolChannel, fromConnection, statsCounterChannel)
 			instance.lastSentOut = fromConnection.timestamp
-			statsCounterChannel <- statUpdate{IncrementCounter, pathSentMessage, 0}
+			writeStats(statsCounterChannel, statUpdate{IncrementCounter, pathSentMessage, 0})
 		} else {
 
 			// Check that the metric value hasn't gone stale
@@ -244,15 +268,15 @@ func main() {
 				instance.unchangedCounter++
 				if instance.outputActive && instance.unchangedCounter >= *maxConsecutiveDryMessages {
 					instance.outputActive = false
-					statsCounterChannel <- statUpdate{IncrementGauge, pathStaleMetricPaths, 0}
+					writeStats(statsCounterChannel, statUpdate{IncrementGauge, pathStaleMetricPaths, 0})
 				}
 			} else {
 				instance.unchangedCounter = 0
 				if !instance.outputActive {
 					instance.outputActive = true
-					statsCounterChannel <- statUpdate{DecrementGauge, pathStaleMetricPaths, 0}
+					writeStats(statsCounterChannel, statUpdate{DecrementGauge, pathStaleMetricPaths, 0})
 					// Send out previous "silenced" metric to make data nicer
-					outgoingToPoolChannel <- metricMessage{fromConnection.metricPath, instance.lastValue, instance.lastTimestamp}
+					writeToOutPool(outgoingToPoolChannel, metricMessage{fromConnection.metricPath, instance.lastValue, instance.lastTimestamp}, statsCounterChannel)
 				}
 			}
 
@@ -264,15 +288,15 @@ func main() {
 
 			// Send out metric if not stale or not chatty
 			if timeToResendStaleMessage || instance.outputActive && !chatty {
-				outgoingToPoolChannel <- fromConnection
+				writeToOutPool(outgoingToPoolChannel, fromConnection, statsCounterChannel)
 				instance.lastSentOut = fromConnection.timestamp
-				statsCounterChannel <- statUpdate{IncrementCounter, pathSentMessage, 0}
+				writeStats(statsCounterChannel, statUpdate{IncrementCounter, pathSentMessage, 0})
 			} else if !instance.outputActive && chatty {
-				statsCounterChannel <- statUpdate{IncrementCounter, pathDiscardedStaleAndChattyMessage, 0}
+				writeStats(statsCounterChannel, statUpdate{IncrementCounter, pathDiscardedStaleAndChattyMessage, 0})
 			} else if !instance.outputActive && !chatty {
-				statsCounterChannel <- statUpdate{IncrementCounter, pathDiscardedStaleMessage, 0}
+				writeStats(statsCounterChannel, statUpdate{IncrementCounter, pathDiscardedStaleMessage, 0})
 			} else if instance.outputActive && chatty {
-				statsCounterChannel <- statUpdate{IncrementCounter, pathDiscardedChattyMessage, 0}
+				writeStats(statsCounterChannel, statUpdate{IncrementCounter, pathDiscardedChattyMessage, 0})
 			}
 		}
 		instance.lastValue = fromConnection.value
@@ -281,17 +305,20 @@ func main() {
 		if timeToCleanup {
 			timeToCleanup = false // Reset the cleanup indicator
 			timeNow := time.Now().Unix()
+			beginTime := time.Now().UnixMilli()
 			for metricPath, metricData := range metric {
 				if timeNow >= (metricData.lastTimestamp + *cleanupMaxAge) {
 					// If a disabled metric is removed, decrement the number of stale
 					// metrics paths since the path doesn't exist in memory anymore
 					if !metricData.outputActive {
-						statsCounterChannel <- statUpdate{DecrementGauge, pathStaleMetricPaths, 0}
+						writeStats(statsCounterChannel, statUpdate{DecrementGauge, pathStaleMetricPaths, 0})
 					}
 					delete(metric, metricPath)
-					statsCounterChannel <- statUpdate{DecrementGauge, pathEncounteredMetricPaths, 0}
+					writeStats(statsCounterChannel, statUpdate{DecrementGauge, pathEncounteredMetricPaths, 0})
 				}
 			}
+			endTime := time.Now().UnixMilli()
+			writeStats(statsCounterChannel, statUpdate{IncreaseCounter, pathCleanupTimeMilli, endTime - beginTime})
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -30,8 +30,8 @@ const (
 	IsNewMetricEnabledByDefault = false
 	StaleResendInterval         = 0
 
-	BlockOnChannelBufferFull = true
-	TcpNoDelay               = false // Disable delay of sending successive small packets
+	BlockOnChannelBufferFullDefault = true
+	TcpNoDelay                      = false // Disable delay of sending successive small packets
 )
 
 // Commandline flag variable definitions
@@ -72,6 +72,8 @@ var (
 )
 
 var timeToCleanup = false
+
+var blockOnChannelBufferFull = BlockOnChannelBufferFullDefault
 
 type StatUpdateType int
 

--- a/stats.go
+++ b/stats.go
@@ -21,6 +21,8 @@ func statsListener(statsCounterChannel chan statUpdate, incomingMessageChannel c
 
 		if metricUpdateMessage.updateType == IncrementCounter {
 			counterStats[metricUpdateMessage.metricPath]++
+		} else if metricUpdateMessage.updateType == IncreaseCounter {
+			counterStats[metricUpdateMessage.metricPath] += metricUpdateMessage.value
 		} else if metricUpdateMessage.updateType == SetCounterValue {
 			counterStats[metricUpdateMessage.metricPath] = metricUpdateMessage.value
 		} else if metricUpdateMessage.updateType == IncrementGauge {
@@ -35,14 +37,17 @@ func statsListener(statsCounterChannel chan statUpdate, incomingMessageChannel c
 				if oldValue, ok := oldCounterStats[key]; ok {
 					if oldValue > 0 {
 						// Send metrics message with statistics using the graphite connection
-						incomingMessageChannel <- metricMessage{metricPath: key, value: float64(value - oldValue), timestamp: timeStamp}
+						writeIncomingMessage(incomingMessageChannel, metricMessage{metricPath: key, value: float64(value - oldValue), timestamp: timeStamp}, statsCounterChannel)
 					}
+				} else {
+					// No previous value to compare with. Just output current value
+					writeIncomingMessage(incomingMessageChannel, metricMessage{metricPath: key, value: float64(value), timestamp: timeStamp}, statsCounterChannel)
 				}
 				oldCounterStats[key] = value
 			}
 			for key, value := range gaugeStats {
 				// Send metrics message with statistics using the graphite connection
-				incomingMessageChannel <- metricMessage{metricPath: key, value: float64(value), timestamp: timeStamp}
+				writeIncomingMessage(incomingMessageChannel, metricMessage{metricPath: key, value: float64(value), timestamp: timeStamp}, statsCounterChannel)
 			}
 		}
 	}
@@ -70,4 +75,10 @@ func initializeInternalMetricsPaths() {
 	pathClientConnectionOpening = `server.hadrianus.` + hostname + `.clientConnectionOpening`
 	pathClientConnectionClosing = `server.hadrianus.` + hostname + `.clientConnectionClosing`
 	pathClientConnectionsActive = `server.hadrianus.` + hostname + `.clientConnectionsActive`
+	pathGoroutines = `server.hadrianus.` + hostname + `.goroutines`
+	pathStatsOverflows = `server.hadrianus.` + hostname + `.statsOverflows`
+	pathToOutPoolOverflows = `server.hadrianus.` + hostname + `.toOutPoolOverflows`
+	pathIncomingMessageOverflows = `server.hadrianus.` + hostname + `.incomingMessageOverflows`
+	pathToOutConnectionOverflows = `server.hadrianus.` + hostname + `.toOutConnectionOverflows`
+	pathCleanupTimeMilli = `server.hadrianus.` + hostname + `.cleanupTimeMilli`
 }

--- a/stats.go
+++ b/stats.go
@@ -76,7 +76,6 @@ func initializeInternalMetricsPaths() {
 	pathClientConnectionClosing = `server.hadrianus.` + hostname + `.clientConnectionClosing`
 	pathClientConnectionsActive = `server.hadrianus.` + hostname + `.clientConnectionsActive`
 	pathGoroutines = `server.hadrianus.` + hostname + `.goroutines`
-	pathStatsOverflows = `server.hadrianus.` + hostname + `.statsOverflows`
 	pathToOutPoolOverflows = `server.hadrianus.` + hostname + `.toOutPoolOverflows`
 	pathIncomingMessageOverflows = `server.hadrianus.` + hostname + `.incomingMessageOverflows`
 	pathToOutConnectionOverflows = `server.hadrianus.` + hostname + `.toOutConnectionOverflows`


### PR DESCRIPTION
Add:
- buffered channel writes
- mechanism to recover from when all channel buffers are full
- internal metrics to give additional insight into the stability of the service
- documentation on internal metrics
- enable "Nagle's algorithm" for output to consumers to improve network performance

This change will improve the service's stability, speed, and observability. However, the changes may increase latency and delays for the metrics consumers due to the added buffering.